### PR TITLE
chore(ci): fix set-build-version script

### DIFF
--- a/libraries/python/setup.py
+++ b/libraries/python/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 # DO_NOT_MODIFY_THIS_VALUE_IS_SET_BY_THE_BUILD_MACHINE
-VERSION = "1.3.0"
+VERSION = "1.10.0"
 
 
 def readme():

--- a/libraries/typescript/package.json
+++ b/libraries/typescript/package.json
@@ -95,6 +95,8 @@
           "assets": [
             "../../CHANGELOG.md",
             "../../docs",
+            "../../package-lock.json",
+            "../../package.json",
             "package-lock.json",
             "package.json",
             "../python/setup.py"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mort_jams",
-  "version": "0.0.0-development",
+  "version": "1.10.0",
   "description": "jams for mort",
   "keywords": [
     "meow"

--- a/tools/set-build-version.ts
+++ b/tools/set-build-version.ts
@@ -3,6 +3,22 @@ const path = require('path')
 const semanticRelease = require('semantic-release')
 const { WritableStreamBuffer } = require('stream-buffers')
 
+const pkgPaths = [
+  path.resolve(path.join(__dirname, '../package.json')),
+  path.resolve(path.join(__dirname, '../libraries/typescript/package.json'))
+]
+const pyPaths = [path.resolve(path.join(__dirname, '../libraries/python/setup.py'))]
+
+const pkgs = [
+  {
+    name: pkgPaths[0],
+    data: require(pkgPaths[0])
+  },
+  {
+    name: path.resolve(pkgPaths[1]),
+    data: require(pkgPaths[1])
+  }
+]
 const stdoutBuffer = new WritableStreamBuffer()
 const stderrBuffer = new WritableStreamBuffer()
 
@@ -24,27 +40,34 @@ function getBuildVersion() {
       const { nextRelease } = result
       return nextRelease.version
     }
-    return Promise.reject(null)
+    return pkgs[0].data.version
   })
 }
 
 getBuildVersion()
   .then((version: any) => {
+    pkgs.forEach((pkg: any) => {
+      pkg.data.version = version
+      console.log(`Setting version to ${version} in ${pkg.name}`)
+      fs.writeFileSync(pkg.name, JSON.stringify(pkg.data, null, 2), 'utf8')
+    })
+
     console.log('--- UPDATING build version in python modules to : ' + version)
-    const filePath = path.join(__dirname, '../libraries/python/setup.py')
-    if (!fs.existsSync(filePath)) {
-      console.error('setup.py for python is missing!')
-      process.exit(1)
-    }
-    const contents = fs.readFileSync(filePath, 'utf8')
-    const regexp = new RegExp(/(VERSION\s?=\s?["\'])\d+\.\d+(?:\.\d+)?(["\'])/)
-    const match = contents.match(regexp)
-    if (!match || match.length !== 3) {
-      console.error('VERSION="1.x.x" string in setup.py was not found.')
-    }
-    const replaceVersion = `${match[1]}${version}${match[2]}`
-    const newContents = contents.replace(regexp, replaceVersion)
-    fs.writeFileSync(filePath, newContents, 'utf8')
+    pyPaths.forEach((filePath: string) => {
+      if (!fs.existsSync(filePath)) {
+        console.error('setup.py for python is missing!')
+        process.exit(1)
+      }
+      const contents = fs.readFileSync(filePath, 'utf8')
+      const regexp = new RegExp(/(VERSION\s?=\s?["\'])\d+\.\d+(?:\.\d+)?(["\'])/)
+      const match = contents.match(regexp)
+      if (!match || match.length !== 3) {
+        console.error('VERSION="1.x.x" string in setup.py was not found.')
+      }
+      const replaceVersion = `${match[1]}${version}${match[2]}`
+      const newContents = contents.replace(regexp, replaceVersion)
+      fs.writeFileSync(filePath, newContents, 'utf8')
+    })
   })
   .catch((e: any) => {
     console.log(e)


### PR DESCRIPTION
 - resolve the file paths unambiguously
 - update package versions as well
 - always update the versions, falling back to root package.json version if there is no semantic-release version to be deployed